### PR TITLE
Float type restriction with handwritten bounds

### DIFF
--- a/algorithms/linfa-logistic/src/hyperparams.rs
+++ b/algorithms/linfa-logistic/src/hyperparams.rs
@@ -9,10 +9,12 @@ use serde::{Deserialize, Serialize};
 /// A generalized logistic regression type that specializes as either binomial logistic regression
 /// or multinomial logistic regression.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct LogisticRegressionParams<F, D: Dimension>(LogisticRegressionValidParams<F, D>);
+#[serde(bound(deserialize = "D: Deserialize<'de>"))]
+pub struct LogisticRegressionParams<F: Float, D: Dimension>(LogisticRegressionValidParams<F, D>);
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct LogisticRegressionValidParams<F, D: Dimension> {
+#[serde(bound(deserialize = "D: Deserialize<'de>"))]
+pub struct LogisticRegressionValidParams<F: Float, D: Dimension> {
     pub(crate) alpha: F,
     pub(crate) fit_intercept: bool,
     pub(crate) max_iterations: u64,

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -526,7 +526,8 @@ fn multi_logistic_grad<F: Float, A: Data<Elem = F>>(
 
 /// A fitted logistic regression which can make predictions
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
-pub struct FittedLogisticRegression<F, C: PartialOrd + Clone> {
+#[serde(bound(deserialize = "C: Deserialize<'de>"))]
+pub struct FittedLogisticRegression<F: Float, C: PartialOrd + Clone> {
     threshold: F,
     intercept: F,
     params: Array1<F>,


### PR DESCRIPTION
I am trying to maintain the Float type restriction.

If I understand the error correctly, serde tries to guess heuristically the trait bounds but it fails.

We need to write by hand the bounds for deserialize. Using `#[serde(bound(deserialize = "D: Deserialize<'de>"))]` as follows it compiles:
```
#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
#[serde(bound(deserialize = "D: Deserialize<'de>"))]
pub struct LogisticRegressionParams<F: Float, D: Dimension>(LogisticRegressionValidParams<F, D>);

#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
#[serde(bound(deserialize = "D: Deserialize<'de>"))]
pub struct LogisticRegressionValidParams<F: Float, D: Dimension> {
    pub(crate) alpha: F,
    pub(crate) fit_intercept: bool,
    pub(crate) max_iterations: u64,
    pub(crate) gradient_tolerance: F,
    pub(crate) initial_params: Option<Array<F, D>>,
}
```

Note: I am learning Rust and I am not sure about the implications of these bounds, I just know that it compiles XD.


Related:
 - https://serde.rs/attr-bound.html